### PR TITLE
Support boolean values for additionalProperties

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -67,7 +67,7 @@ declare namespace AsTypedInternal {
   type ObjectSchema<
     Props,
     ReqProps extends string[],
-    AdditionalProps extends SchemaBase | null = null
+    AdditionalProps extends SchemaBase | boolean = false
   > = SchemaDeclaration<"object"> & {
     required?: ReqProps;
     properties?: Props;
@@ -151,8 +151,10 @@ declare namespace AsTypedInternal {
 
   type ResolveObjectAdditionalProps<
     AdditionalPropsSchema
-  > = AdditionalPropsSchema extends null
+  > = AdditionalPropsSchema extends false
     ? unknown
+    : AdditionalPropsSchema extends true
+    ? { [key: string]: unknown }
     : { [key: string]: ResolveRecursive<AdditionalPropsSchema> };
 
   type ResolveObject<

--- a/test.ts
+++ b/test.ts
@@ -289,3 +289,12 @@ assert(
   }>,
   _ as string
 );
+
+assert(
+  _ as AsTyped<{
+    type: "object";
+    properties: { b: { type: "boolean" } };
+    additionalProperties: true,
+  }>,
+  _ as { b?: boolean, [k: string]: unknown }
+);


### PR DESCRIPTION
The `additionalProperties` property of  an object should be either a boolean value or a schema that additional object properties will be validated against. While trying out `as-typed` npm package as a potential replacement for `json-schema-to-typescript` package, I've noticed that as-typed doesn't currently support `additionalProperties: false`. This PR implements partial support for such usage.

Actually, the default value for `additionalProperties` should be `true` and `json-schema-to-typescript` types the following schema:

```javascript
{
	type: "object",
	properties: {
		s: { type: "string" },
		n: { type: "number" },
	},
}
```

like this:

```typescript
{
	s: string,
	n: number,
	[k: string]: any;
}
```

and removes the `[k: string]` key only if `additionalProperties` is `false` which is technically more correct. But implementing it this way breaks almost all tests so I believe what I've done is an acceptable middle ground for the time being.
